### PR TITLE
Show verify email button conditionally

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,14 @@
                   <button id="btn-send-order" type="button" class="btn btn-success mt-3" onclick="sendOrder()">Send Order</button>
                 </form>
                 <pre id="order-result" class="mt-3"></pre>
-                <a href="#" onclick="sendVerificationEmail(); return false;" class="btn btn-warning"> Verify your email </a>
+                <a
+                  href="#"
+                  id="verify-email-btn"
+                  onclick="sendVerificationEmail(); return false;"
+                  class="btn btn-warning hidden"
+                >
+                  Verify your email
+                </a>
               </div>
             </div>
           </div>

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -77,10 +77,17 @@ const updateUI = async () => {
       eachElement(".user-email", (e) => (e.innerText = user.email));
       eachElement(".auth-invisible", (e) => e.classList.add("hidden"));
       eachElement(".auth-visible", (e) => e.classList.remove("hidden"));
+
+      if (user.email_verified) {
+        document.getElementById("verify-email-btn").classList.add("hidden");
+      } else {
+        document.getElementById("verify-email-btn").classList.remove("hidden");
+      }
     } else {
       document.getElementById("btn-send-order").disabled = true;
       eachElement(".auth-invisible", (e) => e.classList.remove("hidden"));
       eachElement(".auth-visible", (e) => e.classList.add("hidden"));
+      document.getElementById("verify-email-btn").classList.add("hidden");
     }
   } catch (err) {
     console.log("Error updating UI!", err);


### PR DESCRIPTION
## Summary
- toggle the 'Verify your email' button based on email_verified flag
- hide the button by default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870153554c88322a51a4f2e0a3882e6